### PR TITLE
* change from bash to sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 for out in `ls src/body_*.py`
 do


### PR DESCRIPTION
build.bash was compatible with sh, except for the shebang. Now it's possible to run build.sh on systems where by default Bash is not present.
