### PR TITLE
fix for globalLock.ration value

### DIFF
--- a/mongo_lock
+++ b/mongo_lock
@@ -31,7 +31,7 @@ def getServerStatus():
 name = "locked"
 
 def doData():
-    print name + ".value " + str( 100 * getServerStatus()["globalLock"]["ratio"] )
+    print name + ".value " + str( 100 * getServerStatus()["globalLock"]["lockTime"]/getServerStatus()["globalLock"]["totalTime"] )
 
 def doConfig():
 

--- a/mongo_lock
+++ b/mongo_lock
@@ -31,7 +31,7 @@ def getServerStatus():
 name = "locked"
 
 def doData():
-    print name + ".value " + str( 100 * getServerStatus()["globalLock"]["lockTime"]/getServerStatus()["globalLock"]["totalTime"] )
+    print name + ".value " + str( 100 * round(float(getServerStatus()["globalLock"]["lockTime"])/float(getServerStatus()["globalLock"]["totalTime"]), 8) )
 
 def doConfig():
 


### PR DESCRIPTION
Since mongo 2.2 there is no info in globalLock.ratio but it can be counted manually by dividing globalLock.lockTime and globalLock.totalTime. This fix doing it.
