### PR TITLE
globalLock ratio

### DIFF
--- a/mongo_lock
+++ b/mongo_lock
@@ -31,7 +31,7 @@ def getServerStatus():
 name = "locked"
 
 def doData():
-    print name + ".value " + str( 100 * getServerStatus()["globalLock"]["ratio"] )
+        print name + ".value " + str( 100 * getServerStatus()["globalLock"]["lockTime"] / getServerStatus()["globalLock"]["totalTime"] )
 
 def doConfig():
 


### PR DESCRIPTION
["globalLock"]["ratio"] no longer exists. replaced with lockTime devided by totalTime
